### PR TITLE
Return results from experiment

### DIFF
--- a/src/Scientist/Internals/Experiment.cs
+++ b/src/Scientist/Internals/Experiment.cs
@@ -22,13 +22,14 @@ namespace GitHub.Internals
         private Func<T, T, bool> _comparison = DefaultComparison;
         private Func<Task> _beforeRun;
         private readonly Func<Task<bool>> _enabled;
+        private readonly Func<Task<bool>> _enableControl;
         private Action<Operation, Exception> _thrown = _alwaysThrow;
         private Func<Task<bool>> _runIf = _alwaysRun;
         private readonly List<Func<T, T, Task<bool>>> _ignores = new List<Func<T, T, Task<bool>>>();
         private readonly Dictionary<string, dynamic> _contexts = new Dictionary<string, dynamic>();
         private readonly IResultPublisher _resultPublisher;
 
-        public Experiment(string name, Func<Task<bool>> enabled, int concurrentTasks, IResultPublisher resultPublisher)
+        public Experiment(string name, Func<Task<bool>> enabled, Func<Task<bool>> enableControl, int concurrentTasks, IResultPublisher resultPublisher)
         {
             if (concurrentTasks <= 0)
                 throw new ArgumentException("Argument must be greater than 0", nameof(concurrentTasks));
@@ -39,6 +40,7 @@ namespace GitHub.Internals
             _name = name;
             _candidates = new Dictionary<string, Func<Task<T>>>();
             _enabled = enabled;
+            _enableControl = enableControl;
             _concurrentTasks = concurrentTasks;
             _resultPublisher = resultPublisher;
         }
@@ -125,6 +127,7 @@ namespace GitHub.Internals
                 Contexts = _contexts,
                 Control = _control,
                 Enabled = _enabled,
+                EnableControl = _enableControl,
                 Ignores = _ignores,
                 Name = _name,
                 RunIf = _runIf,

--- a/src/Scientist/Internals/ExperimentInstance.cs
+++ b/src/Scientist/Internals/ExperimentInstance.cs
@@ -22,6 +22,7 @@ namespace GitHub.Internals
         internal readonly Func<T, T, bool> Comparator;
         internal readonly Func<Task> BeforeRun;
         internal readonly Func<Task<bool>> Enabled;
+        internal readonly Func<Task<bool>> EnableControl;
         internal readonly Func<Task<bool>> RunIf;
         internal readonly IEnumerable<Func<T, T, Task<bool>>> Ignores;
         internal readonly Dictionary<string, dynamic> Contexts;
@@ -48,6 +49,7 @@ namespace GitHub.Internals
             ConcurrentTasks = settings.ConcurrentTasks;
             Contexts = settings.Contexts;
             Enabled = settings.Enabled;
+            EnableControl = settings.EnableControl;
             RunIf = settings.RunIf;
             Ignores = settings.Ignores;
             Thrown = settings.Thrown;
@@ -62,6 +64,11 @@ namespace GitHub.Internals
             {
                 // Run the control behavior.
                 return await Behaviors[0].Behavior();
+            }
+
+            if (!await ShouldControlRun())
+            {
+                return await Behaviors[1].Behavior();
             }
 
             if (BeforeRun != null)
@@ -161,6 +168,24 @@ namespace GitHub.Internals
                 // Only let the experiment run if at least one candidate (> 1 behaviors) is 
                 // included.  The control is always included behaviors count.
                 return Behaviors.Count > 1 && await Enabled() && await RunIfAllows();
+            }
+            catch (Exception ex)
+            {
+                Thrown(Operation.Enabled, ex);
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Determine whether or not the Control should run.
+        /// </summary>
+        async Task<bool> ShouldControlRun()
+        {
+            try
+            {
+                // Only let the experiment run if at least one candidate (> 1 behaviors) is 
+                // included.  The control is always included behaviors count.
+                return await Enabled() && await RunIfAllows() && await EnableControl();
             }
             catch (Exception ex)
             {

--- a/src/Scientist/Internals/ExperimentSettings.cs
+++ b/src/Scientist/Internals/ExperimentSettings.cs
@@ -19,6 +19,7 @@ namespace GitHub.Internals
         public Dictionary<string, dynamic> Contexts { get; set; }
         public Func<Task<T>> Control { get; set; }
         public Func<Task<bool>> Enabled { get; set; }
+        public Func<Task<bool>> EnableControl { get; set; }
         public IEnumerable<Func<T, T, Task<bool>>> Ignores { get; set; }
         public string Name { get; set; }
         public int ConcurrentTasks { get; set; }

--- a/src/Scientist/Scientist.cs
+++ b/src/Scientist/Scientist.cs
@@ -10,8 +10,11 @@ namespace GitHub
     public class Scientist : IScientist
     {
         static readonly Task<bool> EnabledTask = Task.FromResult(true);
+        static readonly Task<bool> IsEnabledControl = Task.FromResult(true);
+        
         static readonly Lazy<Scientist> _sharedScientist = new Lazy<Scientist>(CreateSharedInstance);
         static Func<Task<bool>> _enabled = () => EnabledTask;
+        static Func<Task<bool>> _enabledControl = () => IsEnabledControl;
         static IResultPublisher _sharedPublisher = new InMemoryResultPublisher();
         readonly IResultPublisher _resultPublisher;
 
@@ -58,7 +61,7 @@ namespace GitHub
         {
             // TODO: Maybe we could automatically generate the name if none is provided using the calling method name. We'd have to 
             // make sure we don't inline this method though.
-            var experimentBuilder = new Experiment<T, TClean>(name, IsEnabledAsync, concurrentTasks, _resultPublisher);
+            var experimentBuilder = new Experiment<T, TClean>(name, IsEnabledAsync, IsEnabledControlAsync ,concurrentTasks, _resultPublisher);
 
             experiment(experimentBuilder);
 
@@ -67,7 +70,7 @@ namespace GitHub
 
         Experiment<T, TClean> Build<T, TClean>(string name, int concurrentTasks, Action<IExperimentAsync<T, TClean>> experiment)
         {
-            var builder = new Experiment<T, TClean>(name, IsEnabledAsync, concurrentTasks, _resultPublisher);
+            var builder = new Experiment<T, TClean>(name, IsEnabledAsync, IsEnabledControlAsync, concurrentTasks, _resultPublisher);
 
             experiment(builder);
 
@@ -85,6 +88,15 @@ namespace GitHub
         /// </summary>
         /// <param name="enabled">A delegate returning an asynchronous task determining if an experiment should run.</param>
         public static void Enabled(Func<Task<bool>> enabled) => _enabled = enabled;
+
+
+        public static void EnabledControl(Func<bool> enabledControl) => EnabledControl(() => Task.FromResult(enabledControl()));
+
+        /// <summary>
+        /// Determines if the control method should be enabled.
+        /// </summary>
+        /// <param name="enabled">A delegate returning an asynchronous task determining if the control method should run.</param>
+        public static void EnabledControl(Func<Task<bool>> enabledControl) => _enabledControl = enabledControl;
 
         /// <summary>
         /// Conduct a synchronous experiment
@@ -185,6 +197,8 @@ namespace GitHub
         /// </remarks>
         protected virtual Task<bool> IsEnabledAsync() => EnabledTask;
 
+        protected virtual Task<bool> IsEnabledControlAsync() => IsEnabledControl;
+
         /// <summary>
         /// This class acts as a proxy to allow the static methods to set the state on an instance of Scientist.
         /// </summary>
@@ -198,6 +212,11 @@ namespace GitHub
             protected override async Task<bool> IsEnabledAsync()
             {
                 return await _enabled();
+            }
+
+            protected override async Task<bool> IsEnabledControlAsync()
+            {
+                return await _enabledControl();
             }
         }
     }

--- a/test/Scientist.Test/IScientistSettings.cs
+++ b/test/Scientist.Test/IScientistSettings.cs
@@ -5,5 +5,7 @@ namespace UnitTests
     public interface IScientistSettings
     {
         Task<bool> Enabled();
+
+        Task<bool> EnableControl();
     }
 }

--- a/test/Scientist.Test/ScientistTests.cs
+++ b/test/Scientist.Test/ScientistTests.cs
@@ -739,6 +739,32 @@ public class TheScientistClass
         }
 
         [Fact]
+        public void ScientistDisablesControl()
+        {
+            const int expectedResult = 42;
+
+            var mock = Substitute.For<IControlCandidate<int>>();
+            mock.Control().Returns(0);
+            mock.Candidate().Returns(expectedResult);
+
+            var settings = Substitute.For<IScientistSettings>();
+            settings.EnableControl().Returns(Task.FromResult(false));
+            using (Swap.EnableControl(settings.EnableControl))
+            {
+                var result = Scientist.Science<int>(nameof(ScientistDisablesControl), experiment =>
+                {
+                    experiment.Use(mock.Control);
+                    experiment.Try(mock.Candidate);
+                });
+
+                Assert.Equal(expectedResult, result);
+                mock.DidNotReceive().Control();
+                mock.Received().Candidate();
+                settings.Received().EnableControl();
+            }
+        }
+
+        [Fact]
         public void KeepingItClean()
         {
             const int expectedResult = 42;

--- a/test/Scientist.Test/Swap.cs
+++ b/test/Scientist.Test/Swap.cs
@@ -32,4 +32,13 @@ public static class Swap
     /// <returns>A new <see cref="Swap{Func{Task{bool}}}"/> instance.</returns>
     public static IDisposable Enabled(Func<Task<bool>> enabled) =>
         new Swap<Func<Task<bool>>>(enabled, () => () => Task.FromResult(true), (del) => Scientist.Enabled(del));
+
+    /// <summary>
+    /// Swaps <see cref="Scientist"/> enabled control value with the input
+    /// parameter, and upon disposal exchanges the enabled back.
+    /// </summary>
+    /// <param name="enabled">The delegate to swap temporarily.</param>
+    /// <returns>A new <see cref="Swap{Func{Task{bool}}}"/> instance.</returns>
+    public static IDisposable EnableControl(Func<Task<bool>> enabled) =>
+        new Swap<Func<Task<bool>>>(enabled, () => () => Task.FromResult(true), (del) => Scientist.EnabledControl(del));
 }


### PR DESCRIPTION
Scientist is designed to always return results from the control,  however during development I have found it helpful to return the result from the candidate rather than the control, i.e. during design and debugging an issue etc.

The following PR exposes a delegate that will can effectively ignore the control and return the result from the first candidate. It has similar affects to turning off Scientist i.e. no comparison reports are generated, no over head etc

```
using GitHub;

...

public void ScientistSetup(){
   Scientist.EnabledControl(() => !HostingEnvironment.IsDevelopmentEnvironment);
}

public bool UseExperimentResult(IUser user)
{
    return Scientist.Science<bool>("widget-permissions", experiment =>
    {
        experiment.Use(() => IsCollaborator(user)); // control
        experiment.Try(() => HasAccess(user)); // candidate
    }); // returns the candidate value
}
```