### PR TITLE
Set Enabled in StaticHelper to afect all instances

### DIFF
--- a/src/Scientist/Scientist.cs
+++ b/src/Scientist/Scientist.cs
@@ -9,9 +9,8 @@ namespace GitHub
     /// </summary>
     public class Scientist : IScientist
     {
-        static readonly Task<bool> EnabledTask = Task.FromResult(true);
-        static readonly Lazy<Scientist> _sharedScientist = new Lazy<Scientist>(CreateSharedInstance);
-        static Func<Task<bool>> _enabled = () => EnabledTask;
+        static readonly Lazy<Scientist> SharedScientist = new Lazy<Scientist>(CreateSharedInstance);
+        static Func<Task<bool>> _enabled = () => Task.FromResult(true);
         static IResultPublisher _sharedPublisher = new InMemoryResultPublisher();
         readonly IResultPublisher _resultPublisher;
 
@@ -43,7 +42,7 @@ namespace GitHub
 
             set
             {
-                if (_sharedScientist.IsValueCreated)
+                if (SharedScientist.IsValueCreated)
                 {
                     throw new InvalidOperationException($"The value of the {nameof(ResultPublisher)} property cannot be changed once an experiment has been run.");
                 }
@@ -52,7 +51,7 @@ namespace GitHub
             }
         }
 
-        static Scientist CreateSharedInstance() => new SharedScientist(ResultPublisher);
+        static Scientist CreateSharedInstance() => new Scientist(ResultPublisher);
 
         Experiment<T, TClean> Build<T, TClean>(string name, int concurrentTasks, Action<IExperiment<T, TClean>> experiment)
         {
@@ -94,7 +93,7 @@ namespace GitHub
         /// <param name="experiment">Experiment callback used to configure the experiment</param>
         /// <returns>The value of the experiment's control function.</returns>
         public static T Science<T>(string name, Action<IExperiment<T>> experiment) =>
-            _sharedScientist.Value.Experiment(name, experiment);
+            SharedScientist.Value.Experiment(name, experiment);
 
         /// <summary>
         /// Conduct a synchronous experiment
@@ -105,7 +104,7 @@ namespace GitHub
         /// <param name="experiment">Experiment callback used to configure the experiment</param>
         /// <returns>The value of the experiment's control function.</returns>
         public static T Science<T, TClean>(string name, Action<IExperiment<T, TClean>> experiment) =>
-            _sharedScientist.Value.Experiment(name, experiment);
+            SharedScientist.Value.Experiment(name, experiment);
 
         /// <summary>
         /// Conduct an asynchronous experiment
@@ -115,7 +114,7 @@ namespace GitHub
         /// <param name="experiment">Experiment callback used to configure the experiment</param>
         /// <returns>The value of the experiment's control function.</returns>
         public static Task<T> ScienceAsync<T>(string name, Action<IExperimentAsync<T>> experiment) =>
-            _sharedScientist.Value.ExperimentAsync(name, experiment);
+            SharedScientist.Value.ExperimentAsync(name, experiment);
 
         /// <summary>
         /// Conduct an asynchronous experiment
@@ -126,7 +125,7 @@ namespace GitHub
         /// <param name="experiment">Experiment callback used to configure the experiment</param>
         /// <returns>The value of the experiment's control function.</returns>
         public static Task<T> ScienceAsync<T>(string name, int concurrentTasks, Action<IExperimentAsync<T>> experiment) =>
-            _sharedScientist.Value.ExperimentAsync(name, concurrentTasks, experiment);
+            SharedScientist.Value.ExperimentAsync(name, concurrentTasks, experiment);
 
         /// <summary>
         /// Conduct an asynchronous experiment
@@ -137,7 +136,7 @@ namespace GitHub
         /// <param name="experiment">Experiment callback used to configure the experiment</param>
         /// <returns>The value of the experiment's control function.</returns>
         public static Task<T> ScienceAsync<T, TClean>(string name, Action<IExperimentAsync<T, TClean>> experiment) =>
-            _sharedScientist.Value.ExperimentAsync(name, experiment);
+            SharedScientist.Value.ExperimentAsync(name, experiment);
 
         /// <summary>
         /// Conduct an asynchronous experiment
@@ -149,7 +148,7 @@ namespace GitHub
         /// <param name="experiment">Experiment callback used to configure the experiment</param>
         /// <returns>The value of the experiment's control function.</returns>
         public static Task<T> ScienceAsync<T, TClean>(string name, int concurrentTasks, Action<IExperimentAsync<T, TClean>> experiment) =>
-            _sharedScientist.Value.ExperimentAsync(name, concurrentTasks, experiment);
+            SharedScientist.Value.ExperimentAsync(name, concurrentTasks, experiment);
 
         /// <summary>
         /// Conduct a synchronous experiment
@@ -183,22 +182,6 @@ namespace GitHub
         /// <remarks>
         /// Override this method to change the default implementation which always returns <see langword="true"/>.
         /// </remarks>
-        protected virtual Task<bool> IsEnabledAsync() => EnabledTask;
-
-        /// <summary>
-        /// This class acts as a proxy to allow the static methods to set the state on an instance of Scientist.
-        /// </summary>
-        private sealed class SharedScientist : Scientist
-        {
-            internal SharedScientist(IResultPublisher resultPublisher)
-                : base(resultPublisher)
-            {
-            }
-
-            protected override async Task<bool> IsEnabledAsync()
-            {
-                return await _enabled();
-            }
-        }
+        protected virtual Task<bool> IsEnabledAsync() => _enabled();
     }
 }


### PR DESCRIPTION
Background for this PR. Having a few experiments running without using the Static Helper, was trying to disable all experiments at once, by using the Enabled method. Turns out it wasn't possible.

To achieve this Had to create a implementation of Scientist and override the IsEnabledAsync.

This PR aims to allow the set of the Enabled func globally, for experiments using the helper and for the implementations. 
The IsEnabledAsync remains virtual so that we can still override the enabled behaviour for a specific one

