### PR TITLE
Fix tag release action, add unit tests for PRs and CodeQL

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -1,0 +1,40 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ] 
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      packages: read
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+         include:
+          - language: actions
+            build-mode: none
+          - language: csharp
+            build-mode: none
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{matrix.language}}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,4 +1,3 @@
-# This runs when a tag gets pushed matching the format below
 name: Release
 
 on:
@@ -12,7 +11,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
 
     steps:
     - uses: actions/checkout@v5
@@ -23,24 +22,25 @@ jobs:
       uses: actions/setup-dotnet@v5
       with:
         dotnet-version: 8.0.x
+        cache-dependency-path: subdir/packages.lock.json
 
     - name: Restore
-      run: dotnet restore
+      run: dotnet restore --locked-mode
 
     - name: Build
       run: dotnet build --configuration Release --no-restore
       
     - name: Test
-      run: dotnet test --configuration Release --no-build --verbosity normal
+      run: dotnet test --configuration Release --no-build --no-restore --verbosity normal
 
     - name: Pack
-      run: dotnet pack --configuration Release -p:PackageVersion=${{ github.ref_name }} --output artifacts/
+      run: dotnet pack --no-build --no-restore --configuration Release -p:PackageVersion=${{ github.ref_name }} --output artifacts/
 
     - name: Publish to GitHub
       working-directory: artifacts
       run: |
         dotnet nuget add source --username ${{ github.actor }} --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name github "https://nuget.pkg.github.com/scientistproject/index.json"
-        dotnet nuget push --source github *.nupkg
+        dotnet nuget push *.nupkg --api-key ${{ secrets.GITHUB_TOKEN }} --source github 
 
     - name: Publish to NuGet
       working-directory: artifacts

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,6 +11,10 @@ env:
 
 jobs:
   build:
+    permissions:
+      contents: read
+      packages: write
+
     runs-on: windows-latest
 
     steps:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,7 +26,7 @@ jobs:
       uses: actions/setup-dotnet@v5
       with:
         dotnet-version: 8.0.x
-        cache-dependency-path: subdir/packages.lock.json
+        cache-dependency-path: '**/packages.lock.json'
 
     - name: Restore
       run: dotnet restore

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,7 +29,7 @@ jobs:
         cache-dependency-path: subdir/packages.lock.json
 
     - name: Restore
-      run: dotnet restore --locked-mode
+      run: dotnet restore
 
     - name: Build
       run: dotnet build --configuration Release --no-restore

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -1,0 +1,44 @@
+name: Unit test
+
+on:
+  pull_request:
+    branches: ["master"]
+
+env:
+  DOTNET_CLI_TELEMETRY_OPTOUT: true
+  DOTNET_NOLOGO: true
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - framework: net8.0
+            sdk: 8.0.x
+            os: ubuntu-latest
+          - framework: net48
+            sdk: none
+            os: windows-latest
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup .NET (skip for net48)
+        if: matrix.sdk != 'none'
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: ${{ matrix.sdk }}
+          cache-dependency-path: subdir/packages.lock.json  
+
+      - name: Restore
+        run: dotnet restore --locked-mode
+
+      - name: Build
+        run: dotnet build --configuration Release --no-restore
+
+      - name: Test
+        run: dotnet test --no-build --no-restore --framework ${{ matrix.framework }} --configuration Release --verbosity normal

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/setup-dotnet@v5
         with:
           dotnet-version: ${{ matrix.sdk }}
-          cache-dependency-path: subdir/packages.lock.json  
+          cache-dependency-path: '**/packages.lock.json'
 
       - name: Restore
         run: dotnet restore

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -10,7 +10,10 @@ env:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
 
 jobs:
-  build:
+  test:
+    permissions:
+      contents: read
+
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -38,7 +38,7 @@ jobs:
           cache-dependency-path: subdir/packages.lock.json  
 
       - name: Restore
-        run: dotnet restore --locked-mode
+        run: dotnet restore
 
       - name: Build
         run: dotnet build --configuration Release --no-restore

--- a/NuGet.config
+++ b/NuGet.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
     <!--To inherit the global NuGet package sources remove the <clear/> line below -->


### PR DESCRIPTION
- This should help build the release by switching to `windows-latest` which has the .NET frameworks preinstalled.

- I've added unit test runs for PRs onto the main branch. This should run in parallel and test against the different frameworks.
| The tests run on parallel with a windows & linux vm, would it be simpler to run on a PR just the linux then before a release do a whole multi framework test?

- CodeQL also runs on PR to main branch & on any commit to main branch. 
| Not convinced running this EVERY PR & then again when its merged in but open to comments