### PR TITLE
feat: Asynchronous experiment cancellation

### DIFF
--- a/Scientist.net.sln
+++ b/Scientist.net.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26730.16
+# Visual Studio Version 18
+VisualStudioVersion = 18.0.11217.181 d18.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Meta", "Meta", "{0FF544BE-E75C-4EF7-AEB3-A534ED5D7BB5}"
 	ProjectSection(SolutionItems) = preProject

--- a/src/Scientist/Candidate.cs
+++ b/src/Scientist/Candidate.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace GitHub
+{
+    public class Candidate<T>
+    {
+        public Candidate(Func<Task<T>> behavior, CancellationToken cancellationToken = default)
+        {
+            Behavior = behavior;
+            CancellationToken = cancellationToken;
+        }
+        public Func<Task<T>> Behavior { get; }
+        public CancellationToken CancellationToken { get; }
+    }
+}

--- a/src/Scientist/IExperiment.cs
+++ b/src/Scientist/IExperiment.cs
@@ -1,6 +1,7 @@
 ﻿using Github.Ordering;
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace GitHub.Internals
@@ -121,20 +122,20 @@ namespace GitHub.Internals
         /// Defines the operation to try.
         /// </summary>
         /// <param name="candidate">The delegate to execute.</param>
-        void Try(Func<Task<T>> candidate);
+        void Try(Func<Task<T>> candidate, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Defines the operation to try.
         /// </summary>
         /// <param name="name"></param>
         /// <param name="candidate">The delegate to execute.</param>
-        void Try(string name, Func<Task<T>> candidate);
+        void Try(string name, Func<Task<T>> candidate, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Defines the operation to actually use.
         /// </summary>
         /// <param name="control">The delegate to execute.</param>
-        void Use(Func<Task<T>> control);
+        void Use(Func<Task<T>> control, CancellationToken cancellationToken = default   );
 
         /// <summary>
         /// Defines a func used to compare results.
@@ -152,6 +153,12 @@ namespace GitHub.Internals
         /// </summary>
         /// <param name="customOrdering">The delgate to execute.</param>
         void UseCustomOrdering(CustomOrderer<T> customOrdering);
+
+        /// <summary>
+        /// Defines the global cancellation token to use
+        /// </summary>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        void WithCancellationToken(CancellationToken cancellationToken = default);
     }
 
     /// <summary>

--- a/src/Scientist/Internals/Experiment.cs
+++ b/src/Scientist/Internals/Experiment.cs
@@ -34,7 +34,6 @@ namespace GitHub.Internals
 
         private CancellationToken _cancellationToken = default;
 
-
         public Experiment(string name, Func<Task<bool>> enabled, int concurrentTasks, IResultPublisher resultPublisher)
         {
             if (concurrentTasks <= 0)
@@ -66,10 +65,6 @@ namespace GitHub.Internals
 
         public void Use(Func<Task<T>> control, CancellationToken cancellationToken = default)
         {
-            var isasd = cancellationToken == default
-              ? true
-              : false;
-
             var tokenToUse = cancellationToken == default
               ? _cancellationToken
               : cancellationToken;

--- a/src/Scientist/Internals/ExperimentSettings.cs
+++ b/src/Scientist/Internals/ExperimentSettings.cs
@@ -1,6 +1,7 @@
 ﻿using Github.Ordering;
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace GitHub.Internals
@@ -14,11 +15,11 @@ namespace GitHub.Internals
     internal class ExperimentSettings<T, TClean>
     {
         public Func<Task> BeforeRun { get; set; }
-        public Dictionary<string, Func<Task<T>>> Candidates { get; set; }
+        public Dictionary<string, Candidate<T>> Candidates { get; set; }
         public Func<T, TClean> Cleaner { get; set; }
         public Func<T, T, bool> Comparator { get; set; }
         public Dictionary<string, dynamic> Contexts { get; set; }
-        public Func<Task<T>> Control { get; set; }
+        public Candidate<T> Control { get; set; }
         public Func<Task<bool>> Enabled { get; set; }
         public IEnumerable<Func<T, T, Task<bool>>> Ignores { get; set; }
         public string Name { get; set; }
@@ -28,5 +29,6 @@ namespace GitHub.Internals
         public Action<Operation, Exception> Thrown { get; set; }
         public IResultPublisher ResultPublisher { get; set; }
         public CustomOrderer<T> CustomOrderer { get; set;  }
+        public CancellationToken CancellationToken { get; set; }
     }
 }

--- a/src/Scientist/NamedBehavior.cs
+++ b/src/Scientist/NamedBehavior.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace GitHub
@@ -7,18 +8,21 @@ namespace GitHub
     {
         string Name { get; }
         Func<Task<T>> Behavior { get; }
+        CancellationToken CancellationToken { get; }
     }
     public class NamedBehavior<T> : INamedBehavior<T>
     {
-        public NamedBehavior(string name, Func<T> method)
-                : this(name, () => Task.FromResult(method()))
+        public NamedBehavior(string name, Func<T> behavior)
         {
+            Name = name;
+            Behavior = () => Task.FromResult(behavior());
         }
 
-        public NamedBehavior(string name, Func<Task<T>> method)
+        public NamedBehavior(string name, Func<Task<T>> behavior, CancellationToken cancellationToken)
         {
-            Behavior = method;
+            Behavior = behavior;
             Name = name;
+            CancellationToken = cancellationToken;
         }
 
         /// <summary>
@@ -30,5 +34,11 @@ namespace GitHub
         /// Gets the behavior to execute during an experiment.
         /// </summary>
         public Func<Task<T>> Behavior { get; }
+
+        /// <summary>
+        /// Gets the cancellation token to use during an experiment.
+        /// </summary>
+        public CancellationToken CancellationToken { get; }
+
     }
 }

--- a/src/Scientist/Result.cs
+++ b/src/Scientist/Result.cs
@@ -6,7 +6,7 @@ namespace GitHub
 {
     public class Result<T, TClean>
     {
-        internal Result(ExperimentInstance<T, TClean> experiment, IEnumerable<Observation<T, TClean>> observations, Observation<T, TClean> control, Dictionary<string, dynamic> contexts)
+        internal Result(ExperimentInstance<T, TClean> experiment, IEnumerable<Observation<T, TClean>> observations, Observation<T, TClean> control, Dictionary<string, dynamic> contexts, bool cancelled)
         {
             Candidates = observations.Where(o => o != control).ToList();
             Control = control;
@@ -19,6 +19,8 @@ namespace GitHub
             IgnoredObservations = mismatchedObservations.Where(m => experiment.IgnoreMismatchedObservation(control, m).Result).ToList();
 
             MismatchedObservations = mismatchedObservations.Except(IgnoredObservations).ToList();
+
+            Cancelled = cancelled;
         }
 
         /// <summary>
@@ -65,5 +67,10 @@ namespace GitHub
         /// Gets the context data supplied to the experiment.
         /// </summary>
         public IReadOnlyDictionary<string, dynamic> Contexts { get; }
+
+        /// <summary>
+        /// Whether the experiment was cancelled.
+        /// </summary>
+        public bool Cancelled { get; }
     }
 }

--- a/test/Scientist.Test/ExperimentTests/AsyncCancellationTests.cs
+++ b/test/Scientist.Test/ExperimentTests/AsyncCancellationTests.cs
@@ -1,0 +1,222 @@
+﻿using FluentAssertions;
+using Github.Ordering;
+using GitHub;
+using GitHub.Internals;
+using NSubstitute;
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using UnitTests;
+using Xunit;
+
+public class AsyncCancellationTests
+{
+    public class WithCancellationTokenTests
+    {
+        [Fact]
+        public async Task When_cancelled_during_control_run_should_throw_operation_cancelled()
+        {
+            var mock = Substitute.For<IControlCandidateTask<int>>();
+            mock.Control().Returns(async call =>
+            {
+                await Task.Delay(5000);
+                return 42;
+            });
+            mock.Candidate().Returns(Task.FromResult(37));
+
+            const string experimentName = nameof(When_cancelled_during_control_run_should_throw_operation_cancelled);
+
+            var resultPublisher = new InMemoryResultPublisher();
+            var scientist = new Scientist(resultPublisher);
+
+            var cts = new CancellationTokenSource();
+
+            cts.Cancel();
+
+            await Assert.ThrowsAsync<OperationCanceledException>(async () =>
+            {
+                await scientist.ExperimentAsync<int>(experimentName, experiment =>
+                {
+                    experiment.WithCancellationToken(cts.Token);
+                    experiment.UseCustomOrdering(behaviours => Task.FromResult(Ordering.ControlFirst(behaviours)));
+                    experiment.Use(mock.Control);
+                    experiment.Try("candidate", mock.Candidate);
+                });
+            });
+        }
+
+        [Fact]
+        public async Task When_cancelled_after_control_has_ran_should_return_cancelled_in_results()
+        {
+            var mock = Substitute.For<IControlCandidateTask<int>>();
+            mock.Control().Returns(Task.FromResult(42));
+            mock.Candidate().Returns(async call =>
+            {
+                await Task.Delay(2000);
+                return 37;
+            });
+
+            const string experimentName = nameof(When_cancelled_after_control_has_ran_should_return_cancelled_in_results);
+
+            var resultPublisher = new InMemoryResultPublisher();
+            var scientist = new Scientist(resultPublisher);
+
+            var cts = new CancellationTokenSource();
+
+            cts.CancelAfter(200);
+
+            var result = await scientist.ExperimentAsync<int>(experimentName, 1, experiment =>
+            {
+                experiment.WithCancellationToken(cts.Token);
+                experiment.UseCustomOrdering(behaviours => Task.FromResult(Ordering.ControlFirst(behaviours)));
+                experiment.Use(mock.Control);
+                experiment.Try("candidate", mock.Candidate);
+            });
+
+            result.Should().Be(42);
+            await mock.Received().Control();
+            await mock.Received().Candidate();
+            Assert.True(resultPublisher.Results<int>(experimentName).First().Cancelled);
+        }
+    }
+
+    public class UseTests
+    {
+        [Fact]
+        public async Task When_cancelled_should_throw_operation_cancelled()
+        {
+            var mock = Substitute.For<IControlCandidateTask<int>>();
+            mock.Control().Returns(async call =>
+            {
+                await Task.Delay(5000);
+                return 42;
+            });
+            mock.Candidate().Returns(Task.FromResult(37));
+
+            const string experimentName = nameof(When_cancelled_should_throw_operation_cancelled);
+
+            var resultPublisher = new InMemoryResultPublisher();
+            var scientist = new Scientist(resultPublisher);
+
+            var cts = new CancellationTokenSource();
+
+            cts.Cancel();
+
+            await Assert.ThrowsAsync<OperationCanceledException>(async () =>
+            {
+                var result = await scientist.ExperimentAsync<int>(experimentName, experiment =>
+                {
+                    experiment.UseCustomOrdering(behaviours => Task.FromResult(Ordering.ControlFirst(behaviours)));
+                    experiment.Use(mock.Control, cts.Token);
+                    experiment.Try("candidate", mock.Candidate);
+                });
+            });
+        }
+    }
+
+    public class TryTests
+    {
+        [Fact]
+        public async Task When_cancelled_should_return_cancelled_in_results()
+        {
+            var mock = Substitute.For<IControlCandidateTask<int>>();
+            mock.Control().Returns(Task.FromResult(42));
+            mock.Candidate().Returns(async call =>
+            {
+                await Task.Delay(5000);
+                return 37;
+            });
+
+            const string experimentName = nameof(When_cancelled_should_return_cancelled_in_results);
+
+            var resultPublisher = new InMemoryResultPublisher();
+            var scientist = new Scientist(resultPublisher);
+
+            var cts = new CancellationTokenSource();
+
+            cts.Cancel();
+
+            var result = await scientist.ExperimentAsync<int>(experimentName, experiment =>
+            {
+                experiment.UseCustomOrdering(behaviours => Task.FromResult(Ordering.ControlFirst(behaviours)));
+                experiment.Use(mock.Control);
+                experiment.Try("candidate", mock.Candidate, cts.Token);
+            });
+
+            result.Should().Be(42);
+
+            await mock.Received().Control();
+            await mock.DidNotReceive().Candidate();
+            resultPublisher.Results<int>(experimentName).First().Candidates[0].Cancelled.Should().BeTrue();
+        }
+    }
+
+    [Fact]
+    public async Task Overriden_control_cancellation_token_should_throw_operation_cancelled()
+    {
+        var mock = Substitute.For<IControlCandidateTask<int>>();
+        mock.Control().Returns(async call =>
+        {
+            await Task.Delay(5000);
+            return 42;
+        });
+        mock.Candidate().Returns(Task.FromResult(37));
+
+        const string experimentName = nameof(Overriden_control_cancellation_token_should_throw_operation_cancelled);
+
+        var resultPublisher = new InMemoryResultPublisher();
+        var scientist = new Scientist(resultPublisher);
+
+        var globalCts = new CancellationTokenSource();
+        var controlCts = new CancellationTokenSource();
+
+        controlCts.Cancel();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(async () =>
+        {
+            await scientist.ExperimentAsync<int>(experimentName, experiment =>
+            {
+                experiment.WithCancellationToken(globalCts.Token);
+                experiment.UseCustomOrdering(behaviours => Task.FromResult(Ordering.ControlFirst(behaviours)));
+                experiment.Use(mock.Control, controlCts.Token);
+                experiment.Try("candidate", mock.Candidate);
+            });
+        });
+    }
+
+    [Fact]
+    public async Task Overriden_candidate_cancellation_token_should_show_cancelled_in_results()
+    {
+        var mock = Substitute.For<IControlCandidateTask<int>>();
+        mock.Control().Returns(Task.FromResult(42));
+        mock.Candidate().Returns(async call =>
+        {
+            await Task.Delay(2000);
+            return 37;
+        });
+
+        const string experimentName = nameof(Overriden_candidate_cancellation_token_should_show_cancelled_in_results);
+
+        var resultPublisher = new InMemoryResultPublisher();
+        var scientist = new Scientist(resultPublisher);
+
+        var globalCts = new CancellationTokenSource();
+        var candidateCts = new CancellationTokenSource();
+
+        candidateCts.Cancel();
+
+        var result = await scientist.ExperimentAsync<int>(experimentName, experiment =>
+         {
+             experiment.WithCancellationToken(globalCts.Token);
+             experiment.UseCustomOrdering(behaviours => Task.FromResult(Ordering.ControlFirst(behaviours)));
+             experiment.Use(mock.Control);
+             experiment.Try("candidate", mock.Candidate, candidateCts.Token);
+         });
+
+        result.Should().Be(42);
+        await mock.Received().Control();
+        await mock.DidNotReceive().Candidate();
+        Assert.True(resultPublisher.Results<int>(experimentName).First().Cancelled);
+    }
+}

--- a/test/Scientist.Test/ScientistTests.cs
+++ b/test/Scientist.Test/ScientistTests.cs
@@ -142,11 +142,9 @@ public class TheScientistClass
         public void EnsureNullGuardIsWorking()
         {
 #if !DEBUG
-           var ex = Assert.Throws<AggregateException>(() =>
+           Assert.Throws<NullReferenceException>(() =>
                 Scientist.Science<object>(null, _ => { })
-            );
-
-           Assert.IsType<NullReferenceException>(ex.InnerException);             
+            );      
 #endif
         }
 


### PR DESCRIPTION
this closes #165

New `experiment.WithCancellationToken()` & overloads for the async `Try` & `Catch`